### PR TITLE
Emails as usernames support

### DIFF
--- a/config.php-example
+++ b/config.php-example
@@ -41,6 +41,9 @@ class phpVBoxConfig {
 
 /* ## THE END OF SETTINGS FOR MODIFIED CONSOLE ## */
 
+/* Replaces spaces " " to "@". It's needed if you want to use E-Mail addresses as usernames */
+var $replaceSpacesToMail = false;
+
 /* Username / Password for system user that runs VirtualBox */
 var $username = 'vbox';
 var $password = 'pass';

--- a/endpoints/command.php
+++ b/endpoints/command.php
@@ -107,7 +107,14 @@ try {
 
 $groups = $machine->getGroups();
 
-if (!$_SESSION['admin'] && !in_array('/'.$_SESSION['user'], $groups)) {
+$newGroups = $groups;
+if ($settings->replaceSpacesToMail) {
+    foreach ($groups as $group) {
+        $newGroups[] = str_replace(" ", "@", $group);
+    }
+}
+
+if (!$_SESSION['admin'] && !in_array('/'.$_SESSION['user'], $newGroups)) {
     die("You don't have access to this machine");
 }
 

--- a/endpoints/command.php
+++ b/endpoints/command.php
@@ -109,6 +109,7 @@ $groups = $machine->getGroups();
 
 $newGroups = $groups;
 if ($settings->replaceSpacesToMail) {
+    $newGroups = [];
     foreach ($groups as $group) {
         $newGroups[] = str_replace(" ", "@", $group);
     }

--- a/endpoints/lib/vboxconnector.php
+++ b/endpoints/lib/vboxconnector.php
@@ -3258,6 +3258,7 @@ class vboxconnector {
 
         $newGroups = $groups;
         if ($this->settings->replaceSpacesToMail) {
+            $newGroups = [];
             foreach ($groups as $group) {
                 $newGroups[] = str_replace(" ", "@", $group);
             }
@@ -3582,6 +3583,7 @@ class vboxconnector {
 
         $newGroups = $groups;
         if ($this->settings->replaceSpacesToMail) {
+            $newGroups = [];
             foreach ($groups as $group) {
                 $newGroups[] = str_replace(" ", "@", $group);
             }
@@ -3676,6 +3678,7 @@ class vboxconnector {
 
         $newGroups = $groups;
         if ($this->settings->replaceSpacesToMail) {
+            $newGroups = [];
             foreach ($groups as $group) {
                 $newGroups[] = str_replace(" ", "@", $group);
             }
@@ -4209,6 +4212,7 @@ class vboxconnector {
 
                 $newGroups = $groups;
                 if ($this->settings->replaceSpacesToMail) {
+                    $newGroups = [];
                     foreach ($groups as $group) {
                         $newGroups[] = str_replace(" ", "@", $group);
                     }
@@ -4220,7 +4224,7 @@ class vboxconnector {
 						'state' => (string)$machine->state,
 						'OSTypeId' => $machine->getOSTypeId(),
 						'owner' => (@$this->settings->enforceVMOwnership ? $machine->getExtraData("phpvb/sso/owner") : ''),
-						'groups' => $groups,
+						'groups' => $newGroups,
 						'lastStateChange' => (string)($machine->lastStateChange/1000),
 						'id' => $machine->id,
 						'currentStateModified' => $machine->currentStateModified,
@@ -4364,6 +4368,7 @@ class vboxconnector {
 
         $newGroups = $groups;
         if ($this->settings->replaceSpacesToMail) {
+            $newGroups = [];
             foreach ($groups as $group) {
                 $newGroups[] = str_replace(" ", "@", $group);
             }

--- a/endpoints/lib/vboxconnector.php
+++ b/endpoints/lib/vboxconnector.php
@@ -3256,7 +3256,14 @@ class vboxconnector {
 
         $vmname = $machine->name;
 
-        if (!$_SESSION['admin'] && !in_array('/'.$_SESSION['user'], $groups)) {
+        $newGroups = $groups;
+        if ($this->settings->replaceSpacesToMail) {
+            foreach ($groups as $group) {
+                $newGroups[] = str_replace(" ", "@", $group);
+            }
+        }
+
+        if (!$_SESSION['admin'] && !in_array('/'.$_SESSION['user'], $newGroups)) {
             throw new Exception("You're not allowed to run this VM");
         }
 
@@ -3573,7 +3580,14 @@ class vboxconnector {
             $groups = $machine->groups;
         }
 
-        if (!$_SESSION['admin'] && !in_array('/'.$_SESSION['user'], $groups)) {
+        $newGroups = $groups;
+        if ($this->settings->replaceSpacesToMail) {
+            foreach ($groups as $group) {
+                $newGroups[] = str_replace(" ", "@", $group);
+            }
+        }
+
+        if (!$_SESSION['admin'] && !in_array('/'.$_SESSION['user'], $newGroups)) {
             return [
                 'password' => ''
             ];
@@ -3660,7 +3674,14 @@ class vboxconnector {
             $groups = $machine->groups;
         }
 
-        if (!$_SESSION['admin'] && !in_array('/'.$_SESSION['user'], $groups)) {
+        $newGroups = $groups;
+        if ($this->settings->replaceSpacesToMail) {
+            foreach ($groups as $group) {
+                $newGroups[] = str_replace(" ", "@", $group);
+            }
+        }
+
+        if (!$_SESSION['admin'] && !in_array('/'.$_SESSION['user'], $newGroups)) {
             throw new Exception("You don't have permission to see details of this server");
         }
 
@@ -4185,8 +4206,15 @@ class vboxconnector {
 				}
 
 				usort($groups, 'strnatcasecmp');
+
+                $newGroups = $groups;
+                if ($this->settings->replaceSpacesToMail) {
+                    foreach ($groups as $group) {
+                        $newGroups[] = str_replace(" ", "@", $group);
+                    }
+                }
 				
-				if (!!$_SESSION['admin'] || in_array('/'.$_SESSION['user'], $groups)) {
+				if (!!$_SESSION['admin'] || in_array('/'.$_SESSION['user'], $newGroups)) {
 					$vmlist[] = array(
 						'name' => @$this->settings->enforceVMOwnership ? preg_replace('/^' . preg_quote($_SESSION['user']) . '_/', '', $machine->name) : $machine->name,
 						'state' => (string)$machine->state,
@@ -4334,7 +4362,14 @@ class vboxconnector {
 			$groups = $m->groups;
 		}
 
-		if (!$_SESSION['admin'] && !in_array('/'.$_SESSION['user'], $groups)) {
+        $newGroups = $groups;
+        if ($this->settings->replaceSpacesToMail) {
+            foreach ($groups as $group) {
+                $newGroups[] = str_replace(" ", "@", $group);
+            }
+        }
+
+		if (!$_SESSION['admin'] && !in_array('/'.$_SESSION['user'], $newGroups)) {
 			return [];
 		}
 


### PR DESCRIPTION
VirtualBox doesn't allow to create groups with "@" symbol. A new parameter in the config allows to name groups like "mypersonalmail gmail.com". This group will be available for user "mypersonalmail@gmail.com"

**REQUIRES TO ADD `var $replaceSpacesToMail = true` IN `config.php`!!!**